### PR TITLE
Revamp: nested lists, unordered option, CSS numbering for ordered option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Layout file with table of contents:
     </div>
     </div>
     <?php $this->yellow->layout("footer") ?>
+    
+## Settings
+
+The following settings can be configured in `system/extensions/yellow-system.ini`: 
+
+`TocLevel`: which heading levels will be included in the table of contents. Options: 1-6.  
+`TocNumbering`: whether the table of contents should be numbered or not. Options: 0 = not numbered, 1 = numbered.
 
 ## Developer
 

--- a/extension.ini
+++ b/extension.ini
@@ -9,3 +9,4 @@ Published: 2022-05-08 10:09:13
 Developer: Anna Svensson
 Tag: feature
 system/extensions/toc.php: toc.php, create, update
+system/extensions/toc.css: toc.css, create, update

--- a/toc.css
+++ b/toc.css
@@ -1,0 +1,15 @@
+/* Table of contents, with nested numbering system */
+
+.content .toc {
+    padding: 0;
+    list-style-position: inside;
+}
+
+.toc ol {
+    list-style-type: decimal;
+}
+
+.toc ol > li::marker {
+    content: counters(list-item,".") ". ";
+    padding: 0 10px;
+}

--- a/toc.php
+++ b/toc.php
@@ -4,38 +4,63 @@
 class YellowToc {
     const VERSION = "0.8.7";
     public $yellow;         // access to API
-    
+
     // Handle initialisation
     public function onLoad($yellow) {
         $this->yellow = $yellow;
+        $this->yellow->system->setDefault("tocLevel", "6"); // shows headings up to nth level
+        $this->yellow->system->setDefault("tocNumbering", "1"); // if 1, ToC is a numbered list
     }
-    
+
     // Handle page content in HTML format
     public function onParseContentHtml($page, $text) {
         $callback = function ($matches) use ($page) {
-            $output = "<ul class=\"toc\">\n";
-            $major = $minor = 0;
             $location = $page->getPage("main")->getLocation(true);
             $rawData = $page->getPage("main")->parserData;
             preg_match_all("/<h(\d) id=\"([^\"]+)\">(.*?)<\/h\d>/i", $rawData, $matches, PREG_SET_ORDER);
-            foreach ($matches as $match) {
-                switch ($match[1]) {
-                    case 2: ++$major; $minor = 0;
-                            $output .= "<li><a href=\"$location#$match[2]\">$major. $match[3]</a></li>\n";
-                            break;
-                    case 3: ++$minor;
-                            $output .= "<li><a href=\"$location#$match[2]\">$major.$minor. $match[3]</a></li>\n";
-                            break;
-                }
+            // I don't know why this works:
+            if ( $this->yellow->system->get("tocNumbering")) {
+                $listType = "ol";
+            } else {
+                $listType = "ul";
             }
-            $output .= "</ul>\n";
+            $output = "<$listType class=\"toc\">";
+            // Initial previous heading level. Guess could also do "if $prevLevel is set" or whatever
+            $prevLevel = 0;
+            $nestedList = 0;
+            foreach ($matches as $match) {
+                // If current heading level is lower than the previous heading level, end nested list
+                if ($match[1] < $prevLevel) {
+                    $nestedList = 0;
+                    $output .= "</$listType>";
+                // If current heading level is higher than the previous level, start nested list. Unless the previous heading level is 0. If desired can add class such as "level-$nestedList" to opening tag.
+                } elseif ($prevLevel != 0 && $match[1] > $prevLevel) {
+                    ++$nestedList;
+                    $output .= "<$listType>";
+                }
+                $output .= "<li><a href=\"$location#$match[2]\">$match[3]</a></li>\n";
+                // Set "previous level" to current heading level and move on to the next heading.
+                $prevLevel = $match[1];
+            }
+            // Adds appropriate number of closing tags for nested lists not followed by a lower heading.
+            for ($i = 0; $i < $nestedList; $i++) {
+                $output .= "</$listType>\n";
+            }
+            $output .= "</$listType>\n";
             return $output;
         };
         return preg_replace_callback("/<p>\[toc\]<\/p>\n/i", $callback, $text);
     }
-    
+
     // Handle page extra data
     public function onParsePageExtra($page, $name) {
+        // Adds ToC stylesheet
+        $output = null;
+        if ($name=="header") {
+            $extensionLocation = $this->yellow->system->get("coreServerBase").$this->yellow->system->get("coreExtensionLocation");
+            $output = "<link rel=\"stylesheet\" type=\"text/css\" media=\"all\" href=\"{$extensionLocation}toc.css\" />\n";
+        }
+        return $output;
         return $name=="toc" ? $this->onParseContentHtml($page, "<p>[toc]</p>\n") : null;
     }
 }

--- a/toc.php
+++ b/toc.php
@@ -18,31 +18,25 @@ class YellowToc {
             $location = $page->getPage("main")->getLocation(true);
             $rawData = $page->getPage("main")->parserData;
             preg_match_all("/<h(\d) id=\"([^\"]+)\">(.*?)<\/h\d>/i", $rawData, $matches, PREG_SET_ORDER);
-            // I don't know why this works:
             if ( $this->yellow->system->get("tocNumbering")) {
                 $listType = "ol";
             } else {
                 $listType = "ul";
             }
             $output = "<$listType class=\"toc\">";
-            // Initial previous heading level. Guess could also do "if $prevLevel is set" or whatever
             $prevLevel = 0;
             $nestedList = 0;
             foreach ($matches as $match) {
-                // If current heading level is lower than the previous heading level, end nested list
                 if ($match[1] < $prevLevel) {
                     $nestedList = 0;
                     $output .= "</$listType>";
-                // If current heading level is higher than the previous level, start nested list. Unless the previous heading level is 0. If desired can add class such as "level-$nestedList" to opening tag.
                 } elseif ($prevLevel != 0 && $match[1] > $prevLevel) {
                     ++$nestedList;
                     $output .= "<$listType>";
                 }
                 $output .= "<li><a href=\"$location#$match[2]\">$match[3]</a></li>\n";
-                // Set "previous level" to current heading level and move on to the next heading.
                 $prevLevel = $match[1];
             }
-            // Adds appropriate number of closing tags for nested lists not followed by a lower heading.
             for ($i = 0; $i < $nestedList; $i++) {
                 $output .= "</$listType>\n";
             }
@@ -54,7 +48,6 @@ class YellowToc {
 
     // Handle page extra data
     public function onParsePageExtra($page, $name) {
-        // Adds ToC stylesheet
         $output = null;
         if ($name=="header") {
             $extensionLocation = $this->yellow->system->get("coreServerBase").$this->yellow->system->get("coreExtensionLocation");


### PR DESCRIPTION
This version allows the user to set whether tables of contents are numbered or not. They can also choose how many heading levels are included in the table of contents. 

Lists are now marked up appropriately, with numbered ToC wrapped in `<ol>` tags and non-numbered in `<ul>`.  Sub-headings are appropriately nested lists. The numbering scheme is implemented with CSS.

Based off the discussion and examples in [this thread](https://github.com/datenstrom/yellow/discussions/544).

To do: 

- translate Settings section of README.md into Deutsch and Svenska 
- perhaps make individual tables of contents customizable with shortcodes, e. g. `[toc ol 4]` for a numbered table of contents that includes headings h1-h4?